### PR TITLE
Context extract

### DIFF
--- a/context_extract.py
+++ b/context_extract.py
@@ -11,26 +11,34 @@ prefix.
 
 import argparse
 
+from rdflib import Graph
+
 #Read in Java property file
-from jproperties import Properties
+import javaproperties
 
 #Home cookin' modules
-from 
+from ontology_crawler import retrieve_crawl_paths
+
+
+def expand(base_url, other_url):
+	pass
 
 def main(fin):
 	#Read in properties file
-	javaprops = Properties()
-	with open(fin,'r') as f:
-		javaprops.load(f, "utf-8")
-	print(javaprops)
+	with open(fin, 'r') as fp:
+		javaprops = javaproperties.load(fp)
+
+	for k in javaprops.keys():
+		print(javaprops[k].split(','))
 
 
 if __name__ == '__main__':
 	parser = argparse.ArgumentParser()
-
 	parser.add_argument(
 		'-f', '--file', type=str,
 		nargs='?', default=None,
 		help="Java properties file to read in. Must be set by user."
-	) 
-	main()
+	)
+
+	args = parser.parse_args()
+	main(args.file)

--- a/context_extract.py
+++ b/context_extract.py
@@ -10,26 +10,72 @@ prefix.
 
 
 import argparse
-
 from rdflib import Graph
-
-#Read in Java property file
+from rdflib.namespace import RDFS, OWL
 import javaproperties
 
 #Home cookin' modules
-from ontology_crawler import retrieve_crawl_paths
+from ontology_crawler import retrieve_crawl_paths_from_context
 
 
-def expand(base_url, other_url):
-	pass
 
-def main(fin):
+def extract_from_contexts(seed_iri,properties,property_f,extract_params,verbose=False,error=None):
+	seed_graph = Graph().parse(seed_iri)
+	print("Loaded seed graph.")
+
+	SEED_QUERY_TEMPLATE = """
+		PREFIX owl: <http://www.w3.org/2002/07/owl#>
+		SELECT DISTINCT ?c WHERE{
+			?c a owl:Class .
+			FILTER(regex(str(?c), "%s"))
+		}
+		"""
+
 	#Read in properties file
-	with open(fin, 'r') as fp:
+	with open(property_f, 'r') as fp:
 		javaprops = javaproperties.load(fp)
+	print("Read properties file.")
 
 	for k in javaprops.keys():
-		print(javaprops[k].split(','))
+		print("Reading graph: ", str(k))
+		#Pull the ontology IRI and associated prefix
+		row = javaprops[k].split(',')
+		prefix = row[0]
+		iri = row[2]
+		#Check whether we have an IRI for the row
+		if iri == '' or iri == seed_iri:
+			continue
+		else:
+			#Read in graph from IRI, use as context
+			context = Graph()
+			FORMATS=['xml','n3','nt','trix','turtle','rdfa']
+			read_success = False
+			for form in FORMATS:
+				try:
+					#If we successfully read our ontology, recurse
+					context = Graph().parse(str(row[0]),format=form)
+					read_success = True
+					print("Read as ", form, ".")
+					break
+				except Exception as e:
+					pass
+			if not read_success:
+				if error is None:
+					raise Exception("Exhausted format list. Failing quickly.")
+				if error == 'ignore':
+					print("Exhausted format list. Quietly ignoring failure.")
+
+			#Expand property paths from context
+			gout = retrieve_crawl_paths_from_context(	
+				seed_graph, 
+				context,
+				properties,
+				seed_query=SEED_QUERY_TEMPLATE % (prefix,),
+				expand_ontologies=True,
+				verbose=verbose,
+				inplace=False,
+				extract_params=extract_params)
+
 
 
 if __name__ == '__main__':
@@ -39,6 +85,23 @@ if __name__ == '__main__':
 		nargs='?', default=None,
 		help="Java properties file to read in. Must be set by user."
 	)
-
 	args = parser.parse_args()
-	main(args.file)
+	#Use CHEAR as our base graph
+	SEED_IRI = 'http://hadatac.org/ont/chear/'
+	PREDICATES = [ #predicates we'll recursively expand paths for 
+		RDFS.subClassOf,
+		OWL.equivalentClass
+	]
+	#Immediate subclasses, full superclass tree
+	extract_params={
+		'upstream' : True, 
+		'downstream' : True, 
+		'up_shallow' : True, 
+		'down_shallow' : False
+	}
+	extract_from_contexts(
+		seed_iri=SEED_IRI,
+		properties=PREDICATES,
+		property_f=args.file,
+		verbose=True,
+		extract_params=extract_params)

--- a/context_extract.py
+++ b/context_extract.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+'''
+File: context_extract.py
+Author: Spencer Norris
+Description: Read in a Java properties file
+per the HADATAC spec and use it to discover
+property paths for classes with the given
+prefix.
+'''
+
+
+import argparse
+
+#Read in Java property file
+from jproperties import Properties
+
+#Home cookin' modules
+from 
+
+def main(fin):
+	#Read in properties file
+	javaprops = Properties()
+	with open(fin,'r') as f:
+		javaprops.load(f, "utf-8")
+	print(javaprops)
+
+
+if __name__ == '__main__':
+	parser = argparse.ArgumentParser()
+
+	parser.add_argument(
+		'-f', '--file', type=str,
+		nargs='?', default=None,
+		help="Java properties file to read in. Must be set by user."
+	) 
+	main()

--- a/context_extract.py
+++ b/context_extract.py
@@ -11,6 +11,7 @@ prefix.
 
 import argparse
 from rdflib import Graph
+from rdflib.util import guess_format
 from rdflib.namespace import RDFS, OWL
 import javaproperties
 
@@ -19,7 +20,21 @@ from ontology_crawler import retrieve_crawl_paths_from_context
 
 
 
-def extract_from_contexts(seed_iri,properties,property_f,extract_params,verbose=False,error=None):
+def extract_from_contexts(
+	seed_iri,properties,
+	property_f,
+	extract_params,
+	dest_dir,
+	verbose=False,error=None):
+	'''
+	Loads in our seed graph from the provided IRI.
+	Then iterates through our provided Java property
+	file, which contains prefixes and IRIs for
+	context ontologies. Entities with the associated
+	prefix are pulled from the seed ontology via the seed query.
+	These seed entities are then used as roots for the property 
+	crawl paths in the associated context ontology. 
+	'''
 	seed_graph = Graph().parse(seed_iri)
 	print("Loaded seed graph.")
 
@@ -37,44 +52,75 @@ def extract_from_contexts(seed_iri,properties,property_f,extract_params,verbose=
 	print("Read properties file.")
 
 	for k in javaprops.keys():
+		print("==========================================")
 		print("Reading graph: ", str(k))
 		#Pull the ontology IRI and associated prefix
 		row = javaprops[k].split(',')
 		prefix = row[0]
 		iri = row[2]
 		#Check whether we have an IRI for the row
-		if iri == '' or iri == seed_iri:
+		if iri == '':
+			print("No IRI provided.")
 			continue
-		else:
-			#Read in graph from IRI, use as context
-			context = Graph()
-			FORMATS=['xml','n3','nt','trix','turtle','rdfa']
-			read_success = False
-			for form in FORMATS:
-				try:
-					#If we successfully read our ontology, recurse
-					context = Graph().parse(str(row[0]),format=form)
-					read_success = True
-					print("Read as ", form, ".")
-					break
-				except Exception as e:
-					pass
-			if not read_success:
-				if error is None:
-					raise Exception("Exhausted format list. Failing quickly.")
-				if error == 'ignore':
-					print("Exhausted format list. Quietly ignoring failure.")
+		if iri == seed_iri:
+			print("Context graph is same as seed graph. Skipping.")
+			continue
 
-			#Expand property paths from context
-			gout = retrieve_crawl_paths_from_context(	
-				seed_graph, 
-				context,
-				properties,
-				seed_query=SEED_QUERY_TEMPLATE % (prefix,),
-				expand_ontologies=True,
-				verbose=verbose,
-				inplace=False,
-				extract_params=extract_params)
+		#Read in graph from IRI, use as context
+		context = Graph()
+		FORMATS=['xml','n3','nt','trix','turtle','rdfa']
+		read_success = False
+		for form in FORMATS:
+			try:
+				#If we successfully read our ontology, recurse
+				context = Graph().parse(iri,format=form)
+				read_success = True
+				print("Read as ", form, ".")
+				break
+			except Exception as e:
+				pass
+		if not read_success:
+			#Last-ditch effort: try to guess the file extension
+			try:
+				print("Exhausted format list. Attempting to guess format...")
+				context = Graph().parse(iri,format=guess_format(iri))
+				print("Read as ", guess_format(iri), ".")
+				break
+			except Exception as e:
+				pass
+			if error is None:
+				raise Exception("Exhausted format list. Failing quickly.")
+			if error == 'ignore':
+				print("Exhausted format list. Quietly ignoring failure.")
+				continue
+
+		#Expand property paths from context
+		gout = retrieve_crawl_paths_from_context(	
+			seed_graph=seed_graph, 
+			context=context,
+			properties=properties,
+			seed_query=SEED_QUERY_TEMPLATE % (prefix,),
+			expand_ontologies=True,
+			verbose=verbose,
+			inplace=False,
+			extract_params=extract_params)
+
+		#Write out
+		gout.serialize(dest_dir + k + '.ttl',format='turtle')
+		print("Wrote out " + dest_dir + k + '.ttl.')
+		del gout
+
+			# try:
+			# 	#Attempt to write out our extracted property paths the canonical way
+			# 	gout.serialize(dest_dir + k + '.ttl',format='turtle')
+			# except Exception as e:
+			# 	#Sometimes rdflib barfs when we try to write out.
+			# 	#In this case, open a file and manually write out our triples
+			# 	print(e)
+			# 	print("Serialization failed. attempting iterative hack.")
+			# 	with open(dest_dir + k + '.ttl','w') as fout:
+			# 		for s,p,o in gout.triples((None,None,None)):
+			# 			#Try something!
 
 
 
@@ -84,6 +130,11 @@ if __name__ == '__main__':
 		'-f', '--file', type=str,
 		nargs='?', default=None,
 		help="Java properties file to read in. Must be set by user."
+	)
+	parser.add_argument(
+		'-d', '--dest', type=str,
+		nargs='?', default='./data/extracts/',
+		help="Directory to which we want to write out our extracted property path graphs."
 	)
 	args = parser.parse_args()
 	#Use CHEAR as our base graph
@@ -104,4 +155,5 @@ if __name__ == '__main__':
 		properties=PREDICATES,
 		property_f=args.file,
 		verbose=True,
-		extract_params=extract_params)
+		extract_params=extract_params,
+		dest_dir=args.dest)

--- a/context_extract.py
+++ b/context_extract.py
@@ -101,6 +101,7 @@ def extract_from_contexts(
 			properties=properties,
 			seed_query=SEED_QUERY_TEMPLATE % (prefix,),
 			expand_ontologies=True,
+			import_error='ignore',
 			verbose=verbose,
 			inplace=False,
 			extract_params=extract_params)

--- a/ontology_crawler.py
+++ b/ontology_crawler.py
@@ -35,7 +35,6 @@ and the connected class (object) is then added to a local graph.
 
 from rdflib import Graph, URIRef
 from rdflib.namespace import RDFS, OWL
-# from SPARQLWrapper import SPARQLWrapper, JSON, XML, N3, RDF
 
 from copy import deepcopy
 import sys
@@ -132,6 +131,7 @@ def retrieve_ontologies(graph, error=None, inplace=True):
 
 			#If unable to parse ontology, decide how to handle error
 			if not read_success:
+				print("Failed to read " + row[0] + ".")
 				if error is None:
 					raise Exception("Exhausted format list. Failing quickly.")
 				if error == 'ignore':
@@ -391,6 +391,9 @@ def retrieve_crawl_paths(
 	#Pull any property paths
 	entity_graph = Graph()
 	entity_graph += extract_property_paths(seeds, graph + ontology_graph, properties, **extract_params)
+
+	#Cleanup
+	del ontology_graph
 
 	#Decide whether or not to lump everything into original graph
 	if inplace:

--- a/ontology_crawler.py
+++ b/ontology_crawler.py
@@ -356,11 +356,8 @@ def retrieve_crawl_paths(graph,properties,
 
 
 
-############### Main Section ####################################################################
+############### Command Line Interface ####################################################################
 
-## TODO: Expand Paulo's base ontology requirement
-def expand(base_url, other_url):
-	pass
 
 if __name__ == '__main__':
 	#Predicates we're interested in expanding paths for

--- a/ontology_crawler.py
+++ b/ontology_crawler.py
@@ -286,7 +286,7 @@ def retrieve_crawl_paths_from_context(
 	context,
 	properties,
 	seed_query=None,
-	expand_ontologies=True,verbose=False,inplace=False,
+	expand_ontologies=True,import_error=None,verbose=False,inplace=False,
 	extract_params={'upstream' : True, 'downstream' : True, 'up_shallow' : True, 'down_shallow' : True}):
 	'''
 	This is a wrapper method for retrieve_crawl_paths.
@@ -313,6 +313,7 @@ def retrieve_crawl_paths_from_context(
 		seed_query=None,
 		seeds=seeds, 
 		expand_ontologies=expand_ontologies,
+		import_error=import_error,
 		verbose=verbose,
 		inplace=inplace, 
 		extract_params=extract_params)
@@ -322,7 +323,7 @@ def retrieve_crawl_paths(
 	graph,
 	properties,
 	seed_query=None,seeds=None,
-	expand_ontologies=True,verbose=False,inplace=False,
+	expand_ontologies=True,import_error=None,verbose=False,inplace=False,
 	extract_params={'upstream' : True, 'downstream' : True, 'up_shallow' : True, 'down_shallow' : True}):
 	'''
 	Method for retrieving entity paths for the given
@@ -382,7 +383,7 @@ def retrieve_crawl_paths(
 
 	#Decide whether to pull in ontologies
 	if expand_ontologies:
-		ontology_graph = retrieve_ontologies(graph,inplace=False)
+		ontology_graph = retrieve_ontologies(graph,inplace=False,error=import_error)
 		if verbose:
 			report_ontologies(ontology_graph)
 	else:


### PR DESCRIPTION
Added tools for reading Java properties files providing contexts to extract files from. This might eventually get ripped from the repo and pushed into a Gist instead, since it is a very specific use case. Refactored BioPortal crawler, can probably branch and turn into a generic SPARQLWrapper crawler. Also added generic `owl:Class` statements; need to branch and fix since these will append the statement to any input entity, which shouldn't be the case.